### PR TITLE
Add offer code handler to api

### DIFF
--- a/app.js
+++ b/app.js
@@ -64,6 +64,7 @@ app.post('/pay', cors(corsOptions), function(req, res, next) {
     card: req.body.stripeToken,
     email: req.body.email,
     plan: config.stripePlan,
+    coupon: req.body.offerCode,
     metadata: metadata
   }, function(err, customer) {
     if (err) {


### PR DESCRIPTION
We now accept an offer code (i.e. a coupon) in our webform. This will handle that code and send it to stripe.

@jeremiak you want to check this out? Small change.
